### PR TITLE
String Comparison with OrdinalIgnoreCase

### DIFF
--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -109,7 +109,11 @@ namespace Dapper.Contrib.Extensions
 
             if (keyProperties.Count == 0)
             {
-                var idProp = allProperties.Find(p => string.Equals(p.Name, "id", StringComparison.CurrentCultureIgnoreCase));
+                var idProp = allProperties.Find(p => string.Equals(p.Name, "id", StringComparison.OrdinalIgnoreCase));
+                if (idProp == null)
+                {
+                    idProp = allProperties.Find(p => string.Equals(p.Name, "id", StringComparison.CurrentCultureIgnoreCase));
+                }
                 if (idProp != null && !idProp.GetCustomAttributes(true).Any(a => a is ExplicitKeyAttribute))
                 {
                     keyProperties.Add(idProp);


### PR DESCRIPTION
#73  

During the string comparison instead of 'CurrentCultureIgnoreCase', 'OrdinalIgnoreCase' is used. As a result, the case of unit tests in Turkish systems resulting with a failure is resolved.

Old PR : https://github.com/DapperLib/Dapper/pull/1023
