### PR TITLE
Added ormliteconnection to AdapterDictionary

### DIFF
--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -67,6 +67,7 @@ namespace Dapper.Contrib.Extensions
                 ["sqlceconnection"] = new SqlCeServerAdapter(),
                 ["npgsqlconnection"] = new PostgresAdapter(),
                 ["sqliteconnection"] = new SQLiteAdapter(),
+                ["ormliteconnection"] = new SQLiteAdapter(),
                 ["mysqlconnection"] = new MySqlAdapter(),
                 ["fbconnection"] = new FbAdapter()
             };


### PR DESCRIPTION
It is possible to do unit-tests with an InMemory SqlLite db using OrmLiteConnectionFactory (see: https://mikhail.io/2016/02/unit-testing-dapper-repositories/)

When using Dapper.Contrib, it will not recognize the connection and will default. 

An ideal solution would make it possible to override/inject the AdapterDictionary so it would be easily extensible but that would be a bigger project.
What do you think?