### PR TITLE
Add support ColumnAttribute for different column name

### DIFF
--- a/Dapper.sln
+++ b/Dapper.sln
@@ -16,7 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		version.json = version.json
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Contrib", "Dapper.Contrib\Dapper.Contrib.csproj", "{4E409F8F-CFBB-4332-8B0A-FD5A283051FD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Contrib", "src\Dapper.Contrib\Dapper.Contrib.csproj", "{4E409F8F-CFBB-4332-8B0A-FD5A283051FD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Tests.Contrib", "tests\Dapper.Tests.Contrib\Dapper.Tests.Contrib.csproj", "{DAB3C5B7-BCD1-4A5F-BB6B-50D2BB63DB4A}"
 EndProject

--- a/Readme.md
+++ b/Readme.md
@@ -166,7 +166,19 @@ Dapper.Contrib makes use of some optional attributes:
     ```
 * `[Write(true/false)]` -  this property is (not) writeable
 * `[Computed]` - this property is computed and should not be part of updates
+* `[Column("Columnname")]` - this property has a different name in the Database
+    * Property is called EmployeeId but Column in DB is called employee_id
 
+      ```csharp
+      public class Employee
+      {
+          [ExplicitKey]
+          [Column("employee_id")]
+          public Guid EmployeeId { get; set; }
+          public string Name { get; set; }
+      }
+      ```
+      
 Limitations and caveats
 -------
 

--- a/src/Dapper.Contrib/PropertyInfoExtensions.cs
+++ b/src/Dapper.Contrib/PropertyInfoExtensions.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+
+namespace Dapper.Contrib.Extensions
+{
+    /// <summary>
+    /// Map <see cref="PropertyInfo"/> to database column extensions
+    /// </summary>
+    public static class PropertyInfoExtensions
+    {
+        private static readonly ConcurrentDictionary<PropertyInfo, string> PropertyColumnName = new ConcurrentDictionary<PropertyInfo, string>();
+        
+        /// <summary>
+        /// The function to get a column name from a given <see cref="PropertyInfo"/>
+        /// </summary>
+        /// <param name="property">The <see cref="PropertyInfo"/> to get a column name for.</param>
+        public delegate string ColumnNameMapperDelegate(PropertyInfo property);
+        
+        /// <summary>
+        /// Specify a custom column name mapper based on the POCO type name
+        /// </summary>
+#pragma warning disable CA2211 // Non-constant fields should not be visible - I agree with you, but we can't do that until we break the API
+        public static ColumnNameMapperDelegate ColumnNameMapper;
+#pragma warning restore CA2211 // Non-constant fields should not be visible
+
+        /// <summary>
+        /// Get database column name from <see cref="PropertyInfo"/>
+        /// </summary>
+        /// <param name="property">The <see cref="PropertyInfo"/> to get a column name for.</param>
+        public static string ColumnName(this PropertyInfo property)
+        {
+            if (PropertyColumnName.TryGetValue(property, out string name)) return name;
+
+            if (ColumnNameMapper != null)
+            {
+                name = ColumnNameMapper(property);
+            }
+            else
+            {
+                //NOTE: This as dynamic trick falls back to handle both our own Column-attribute as well as the one in EntityFramework 
+                var columnAttrName =
+                    property.GetCustomAttribute<ColumnAttribute>(true)?.Name
+                    ?? (property.GetCustomAttributes(true).FirstOrDefault(attr => attr.GetType().Name == "ColumnAttribute") as dynamic)?.Name;
+
+                name = columnAttrName != null 
+                    ? columnAttrName 
+                    : property.Name;
+            }
+
+            PropertyColumnName[property] = name;
+            return name;
+        }
+    }
+}

--- a/src/Dapper.Contrib/TypeExtensions.cs
+++ b/src/Dapper.Contrib/TypeExtensions.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reflection;
+
+namespace Dapper.Contrib.Extensions
+{
+    /// <summary>
+    /// Map <see cref="Type"/> to database table extensions
+    /// </summary>
+    public static class TypeExtensions
+    {
+        private static readonly ConcurrentDictionary<RuntimeTypeHandle, string> TypeTableName = new ConcurrentDictionary<RuntimeTypeHandle, string>();
+        
+        /// <summary>
+        /// The function to get a table name from a given <see cref="Type"/>
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> to get a table name for.</param>
+        public delegate string TableNameMapperDelegate(Type type);
+
+        /// <summary>
+        /// Specify a custom table name mapper based on the POCO type name
+        /// </summary>
+#pragma warning disable CA2211 // Non-constant fields should not be visible - I agree with you, but we can't do that until we break the API
+        public static TableNameMapperDelegate TableNameMapper;
+#pragma warning restore CA2211 // Non-constant fields should not be visible
+        
+        /// <summary>
+        /// Get database table name from <see cref="Type"/>
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> to get a table name for.</param>
+        public static string TableName(this Type type)
+        {
+            if (TypeTableName.TryGetValue(type.TypeHandle, out string name)) return name;
+
+            if (TableNameMapper != null)
+            {
+                name = TableNameMapper(type);
+            }
+            else
+            {
+                //NOTE: This as dynamic trick falls back to handle both our own Table-attribute as well as the one in EntityFramework 
+                var tableAttrName =
+                    type.GetCustomAttribute<TableAttribute>(false)?.Name
+                    ?? (type.GetCustomAttributes(false).FirstOrDefault(attr => attr.GetType().Name == "TableAttribute") as dynamic)?.Name;
+
+                if (tableAttrName != null)
+                {
+                    name = tableAttrName;
+                }
+                else
+                {
+                    name = type.Name + "s";
+                    if (type.IsInterface && name.StartsWith("I"))
+                        name = name.Substring(1);
+                }
+            }
+
+            TypeTableName[type.TypeHandle] = name;
+            return name;
+        }
+    }
+}

--- a/tests/Dapper.Tests.Contrib/TestSuites.cs
+++ b/tests/Dapper.Tests.Contrib/TestSuites.cs
@@ -41,7 +41,7 @@ namespace Dapper.Tests.Contrib
                 dropTable("Users");
                 connection.Execute("CREATE TABLE Users (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null, Age int not null);");
                 dropTable("Automobiles");
-                connection.Execute("CREATE TABLE Automobiles (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null);");
+                connection.Execute("CREATE TABLE Automobiles (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null, Computed AS Concat('[',Name,']'));");
                 dropTable("Results");
                 connection.Execute("CREATE TABLE Results (Id int IDENTITY(1,1) not null, Name nvarchar(100) not null, [Order] int not null);");
                 dropTable("ObjectX");
@@ -61,7 +61,7 @@ namespace Dapper.Tests.Contrib
     public class MySqlServerTestSuite : TestSuite
     {
         public static string ConnectionString { get; } =
-            GetConnectionString("MySqlConnectionString", "Server=localhost;Database=tests;Uid=test;Pwd=pass;UseAffectedRows=false;");
+            GetConnectionString("MySqlConnectionString", "Server=localhost;Database=test;Uid=root;Pwd=root;UseAffectedRows=false;");
 
         public override IDbConnection GetConnection()
         {
@@ -87,7 +87,7 @@ namespace Dapper.Tests.Contrib
                     dropTable("Users");
                     connection.Execute("CREATE TABLE Users (Id int not null AUTO_INCREMENT PRIMARY KEY, Name nvarchar(100) not null, Age int not null);");
                     dropTable("Automobiles");
-                    connection.Execute("CREATE TABLE Automobiles (Id int not null AUTO_INCREMENT PRIMARY KEY, Name nvarchar(100) not null);");
+                    connection.Execute("CREATE TABLE Automobiles (Id int not null AUTO_INCREMENT PRIMARY KEY, Name nvarchar(100) not null, Computed nvarchar(150) GENERATED ALWAYS AS (Concat('[',Name,']')));");
                     dropTable("Results");
                     connection.Execute("CREATE TABLE Results (Id int not null AUTO_INCREMENT PRIMARY KEY, Name nvarchar(100) not null, `Order` int not null);");
                     dropTable("ObjectX");
@@ -130,7 +130,7 @@ namespace Dapper.Tests.Contrib
                 connection.Execute("CREATE TABLE Stuff (TheId integer primary key autoincrement not null, Name nvarchar(100) not null, Created DateTime null) ");
                 connection.Execute("CREATE TABLE People (Id integer primary key autoincrement not null, Name nvarchar(100) not null) ");
                 connection.Execute("CREATE TABLE Users (Id integer primary key autoincrement not null, Name nvarchar(100) not null, Age int not null) ");
-                connection.Execute("CREATE TABLE Automobiles (Id integer primary key autoincrement not null, Name nvarchar(100) not null) ");
+                connection.Execute("CREATE TABLE Automobiles (Id integer primary key autoincrement not null, Name nvarchar(100) not null, Computed nvarchar(150) GENERATED ALWAYS AS ('[' || Name || ']')) ");
                 connection.Execute("CREATE TABLE Results (Id integer primary key autoincrement not null, Name nvarchar(100) not null, [Order] int not null) ");
                 connection.Execute("CREATE TABLE ObjectX (ObjectXId nvarchar(100) not null, Name nvarchar(100) not null) ");
                 connection.Execute("CREATE TABLE ObjectY (ObjectYId integer not null, Name nvarchar(100) not null) ");


### PR DESCRIPTION
Added Attribute [Column(string)] for when the column in the DB is named differently from the Property in the model. Fixed #129  

Breaking changes:
- In ISqlAdapter changed method AppendColumnNameEqualsValue
- Tables in database should contains columns for all properties