### PR TITLE
Escape id column name in Get, GetAsync

### DIFF
--- a/Dapper.sln
+++ b/Dapper.sln
@@ -16,7 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		version.json = version.json
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Contrib", "Dapper.Contrib\Dapper.Contrib.csproj", "{4E409F8F-CFBB-4332-8B0A-FD5A283051FD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Contrib", "src\Dapper.Contrib\Dapper.Contrib.csproj", "{4E409F8F-CFBB-4332-8B0A-FD5A283051FD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Tests.Contrib", "tests\Dapper.Tests.Contrib\Dapper.Tests.Contrib.csproj", "{DAB3C5B7-BCD1-4A5F-BB6B-50D2BB63DB4A}"
 EndProject

--- a/src/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -30,7 +30,12 @@ namespace Dapper.Contrib.Extensions
                 var key = GetSingleKey<T>(nameof(GetAsync));
                 var name = GetTableName(type);
 
-                sql = $"SELECT * FROM {name} WHERE {key.Name} = @id";
+                var adapter = GetFormatter(connection);
+
+                var sbGetQuery = new StringBuilder($"SELECT * FROM {name} WHERE ");
+                adapter.AppendColumnName(sbGetQuery, key.Name);
+                sbGetQuery.Append(" = @id");
+                sql = sbGetQuery.ToString();
                 GetQueries[type.TypeHandle] = sql;
             }
 

--- a/src/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -25,7 +25,11 @@ namespace Dapper.Contrib.Extensions
         public static async Task<T> GetAsync<T>(this IDbConnection connection, dynamic id, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
         {
             var type = typeof(T);
-            if (!GetQueries.TryGetValue(type.TypeHandle, out string sql))
+
+            // get query caching depends on connection specific formatting
+            var typeTuple = Tuple.Create(connection.GetType().TypeHandle, type.TypeHandle);
+            
+            if (!GetQueries.TryGetValue(typeTuple, out string sql))
             {
                 var key = GetSingleKey<T>(nameof(GetAsync));
                 var name = GetTableName(type);
@@ -36,7 +40,7 @@ namespace Dapper.Contrib.Extensions
                 adapter.AppendColumnName(sbGetQuery, key.Name);
                 sbGetQuery.Append(" = @id");
                 sql = sbGetQuery.ToString();
-                GetQueries[type.TypeHandle] = sql;
+                GetQueries[typeTuple] = sql;
             }
 
             var dynParams = new DynamicParameters();
@@ -88,13 +92,13 @@ namespace Dapper.Contrib.Extensions
             var type = typeof(T);
             var cacheType = typeof(List<T>);
 
-            if (!GetQueries.TryGetValue(cacheType.TypeHandle, out string sql))
+            if (!GetAllQueries.TryGetValue(cacheType.TypeHandle, out string sql))
             {
                 GetSingleKey<T>(nameof(GetAll));
                 var name = GetTableName(type);
 
                 sql = "SELECT * FROM " + name;
-                GetQueries[cacheType.TypeHandle] = sql;
+                GetAllQueries[cacheType.TypeHandle] = sql;
             }
 
             if (!type.IsInterface)

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -56,7 +56,11 @@ namespace Dapper.Contrib.Extensions
         private static readonly ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>> ExplicitKeyProperties = new ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>>();
         private static readonly ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>> TypeProperties = new ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>>();
         private static readonly ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>> ComputedProperties = new ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<PropertyInfo>>();
-        private static readonly ConcurrentDictionary<RuntimeTypeHandle, string> GetQueries = new ConcurrentDictionary<RuntimeTypeHandle, string>();
+        private static readonly ConcurrentDictionary<RuntimeTypeHandle, string> GetAllQueries = new ConcurrentDictionary<RuntimeTypeHandle, string>();
+        /// <summary>
+        /// Key is a composite of connection type, entity type
+        /// </summary>
+        private static readonly ConcurrentDictionary<Tuple<RuntimeTypeHandle, RuntimeTypeHandle>, string> GetQueries = new ConcurrentDictionary<Tuple<RuntimeTypeHandle, RuntimeTypeHandle>, string>();
         private static readonly ConcurrentDictionary<RuntimeTypeHandle, string> TypeTableName = new ConcurrentDictionary<RuntimeTypeHandle, string>();
 
         private static readonly ISqlAdapter DefaultAdapter = new SqlServerAdapter();
@@ -171,7 +175,10 @@ namespace Dapper.Contrib.Extensions
         {
             var type = typeof(T);
 
-            if (!GetQueries.TryGetValue(type.TypeHandle, out string sql))
+            // get query caching depends on connection specific formatting
+            var typeTuple = Tuple.Create(connection.GetType().TypeHandle, type.TypeHandle);
+
+            if (!GetQueries.TryGetValue(typeTuple, out string sql))
             {
                 var key = GetSingleKey<T>(nameof(Get));
                 var name = GetTableName(type);
@@ -182,7 +189,7 @@ namespace Dapper.Contrib.Extensions
                 adapter.AppendColumnName(sbGetQuery, key.Name);
                 sbGetQuery.Append(" = @id");
                 sql = sbGetQuery.ToString();
-                GetQueries[type.TypeHandle] = sql;
+                GetQueries[typeTuple] = sql;
             }
 
             var dynParams = new DynamicParameters();
@@ -239,13 +246,13 @@ namespace Dapper.Contrib.Extensions
             var type = typeof(T);
             var cacheType = typeof(List<T>);
 
-            if (!GetQueries.TryGetValue(cacheType.TypeHandle, out string sql))
+            if (!GetAllQueries.TryGetValue(cacheType.TypeHandle, out string sql))
             {
                 GetSingleKey<T>(nameof(GetAll));
                 var name = GetTableName(type);
 
                 sql = "select * from " + name;
-                GetQueries[cacheType.TypeHandle] = sql;
+                GetAllQueries[cacheType.TypeHandle] = sql;
             }
 
             if (!type.IsInterface) return connection.Query<T>(sql, null, transaction, commandTimeout: commandTimeout);

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -176,7 +176,12 @@ namespace Dapper.Contrib.Extensions
                 var key = GetSingleKey<T>(nameof(Get));
                 var name = GetTableName(type);
 
-                sql = $"select * from {name} where {key.Name} = @id";
+                var adapter = GetFormatter(connection);
+
+                var sbGetQuery = new StringBuilder($"SELECT * FROM {name} WHERE ");
+                adapter.AppendColumnName(sbGetQuery, key.Name);
+                sbGetQuery.Append(" = @id");
+                sql = sbGetQuery.ToString();
                 GetQueries[type.TypeHandle] = sql;
             }
 


### PR DESCRIPTION
Get\GetAsync do not work correctly with SQL Server when the Id column is a reserved keyword (e.g. "Key") marked with the `ExplicitKeyAttribute`.

Use the adapter specific column name escaping to resolve the issue.

resolves #150