### PR TITLE
Added support to set a custom parameter prefix (instead of '@')

### DIFF
--- a/Dapper.sln
+++ b/Dapper.sln
@@ -16,7 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		version.json = version.json
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Contrib", "Dapper.Contrib\Dapper.Contrib.csproj", "{4E409F8F-CFBB-4332-8B0A-FD5A283051FD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Contrib", "src\Dapper.Contrib\Dapper.Contrib.csproj", "{4E409F8F-CFBB-4332-8B0A-FD5A283051FD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Tests.Contrib", "tests\Dapper.Tests.Contrib\Dapper.Tests.Contrib.csproj", "{DAB3C5B7-BCD1-4A5F-BB6B-50D2BB63DB4A}"
 EndProject

--- a/Readme.md
+++ b/Readme.md
@@ -167,12 +167,12 @@ Dapper.Contrib makes use of some optional attributes:
 * `[Write(true/false)]` -  this property is (not) writeable
 * `[Computed]` - this property is computed and should not be part of updates
 
-Custom prefix for parameters
+Custom parameter prefix
 -------
 By default Dapper.Contrib uses the character `@` as parameter prefix for SQL query and parameters collection. This can be changed throught the `GetParameterPrefixForQuery` and `GetParameterPrefixForParameterCollection` delegates:
 
 ```csharp
-// Defines ':' as prefix for SQL query and '?' for parameters 
+// Defines ':' as prefix for SQL query and '?' for parameters collection
 SqlMapperExtensions.GetParameterPrefixForQuery = () => ":";
 SqlMapperExtensions.GetParameterPrefixForParameterCollection = () => "?";
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -169,7 +169,7 @@ Dapper.Contrib makes use of some optional attributes:
 
 Custom parameter prefix
 -------
-By default Dapper.Contrib uses the character `@` as parameter prefix for SQL query and parameters collection. This can be changed throught the `GetParameterPrefixForQuery` and `GetParameterPrefixForParameterCollection` delegates:
+By default Dapper.Contrib uses the character `@` as parameter prefix for SQL query and parameters collection. This can be changed through the `GetParameterPrefixForQuery` and `GetParameterPrefixForParameterCollection` delegates:
 
 ```csharp
 // Defines ':' as prefix for SQL query and '?' for parameters collection

--- a/Readme.md
+++ b/Readme.md
@@ -167,6 +167,18 @@ Dapper.Contrib makes use of some optional attributes:
 * `[Write(true/false)]` -  this property is (not) writeable
 * `[Computed]` - this property is computed and should not be part of updates
 
+Custom prefix for parameters
+-------
+By default Dapper.Contrib uses the character `@` as parameter prefix for SQL query and parameters collection. This can be changed throught the `GetParameterPrefixForQuery` and `GetParameterPrefixForParameterCollection` delegates:
+
+```csharp
+// Defines ':' as prefix for SQL query and '?' for parameters 
+SqlMapperExtensions.GetParameterPrefixForQuery = () => ":";
+SqlMapperExtensions.GetParameterPrefixForParameterCollection = () => "?";
+```
+
+This setting may be useful when using Dapper.Contrib with database providers that use other character as a parameter prefix.
+
 Limitations and caveats
 -------
 

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -555,6 +555,9 @@ namespace Dapper.Contrib.Extensions
         public static GetParameterPrefixDelegate GetParameterPrefixForParameterCollection;
 #pragma warning restore CA2211 // Non-constant fields should not be visible
 
+        /// <summary>
+        /// '@'
+        /// </summary>
         private const string  _defaultParameterPrefix = "@";
 
         private static string GetParameterPrefixQuery()

--- a/tests/Dapper.Tests.Contrib/TestSuite.cs
+++ b/tests/Dapper.Tests.Contrib/TestSuite.cs
@@ -375,6 +375,15 @@ namespace Dapper.Tests.Contrib
             InsertHelper(src => src.ToList());
         }
 
+        [Fact]
+        public void InsertListWithCustomParameterPrefix()
+        {
+            SqlMapperExtensions.GetParameterPrefixForQuery = () => "@";
+            SqlMapperExtensions.GetParameterPrefixForParameterCollection = () => "@";
+            
+            InsertHelper(src => src.ToList());
+        }
+
         private void InsertHelper<T>(Func<IEnumerable<User>, T> helper)
             where T : class
         {


### PR DESCRIPTION
Added support for defining a custom parameter prefix (instead of the hard-coded `@`) for SQL query and parameters collection, separately. 

Some providers have problems with `@` as a default parameter prefix when used with Dapper, such as Devart dotConnect for MySQL. In that specific case, we have to use `:` on the SQL query instead (e.g: `SELECT foo FROM table WHERE bar=:parameter`). With this feature we are able to use Dapper.Contrib on those scenarios. 

The configuration was implemented using delegate pattern (same way of `GetDatabaseType` and `TableNameMapper`) 

Example of use:
```
SqlMapperExtensions.GetParameterPrefixForQuery = () => ":";
SqlMapperExtensions.GetParameterPrefixForParameterCollection = () => "@";
```


This PR may also solve/fix:
#14 
#124 
#127 

Related topics:
https://github.com/DapperLib/Dapper/issues/1296
https://github.com/DapperLib/Dapper/issues/1232