### PR TITLE
Refactor property info handling, allow keys different from Id property 

### DIFF
--- a/src/Dapper.Contrib/SqlMapperExtensions.Async.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.Async.cs
@@ -301,7 +301,7 @@ namespace Dapper.Contrib.Extensions
                 }
             }
 
-            var keyProperties = KeyPropertiesCache(type);
+            var keyProperties = KeyPropertiesCache(type).ToList();
             var explicitKeyProperties = ExplicitKeyPropertiesCache(type);
             if (keyProperties.Count == 0 && explicitKeyProperties.Count == 0)
                 throw new ArgumentException("Entity must have at least one [Key] or [ExplicitKey] property");

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -694,7 +694,7 @@ namespace Dapper.Contrib.Extensions
             }
 
             public IReadOnlyCollection<PropertyInfo> KeyPropertiesExceptId =>
-                KeyProperties.Where(p => p != PropertyNamedId).ToArray();
+                KeyProperties.Where(p => !IsPropertyNamedId(p)).ToArray();
 
 
             /// <summary>
@@ -813,8 +813,7 @@ namespace Dapper.Contrib.Extensions
                 };
 
             private DataException GetTooManyKeysException(string method) =>
-                new(
-                    $"{method}<T> only supports an entity with a single [Key] or [ExplicitKey] property. [Key] Count: {KeyProperties.Count}, [ExplicitKey] Count: {ExplicitKeyProperties.Count}");
+                new("{method}<T> only supports an entity with a single [Key] or [ExplicitKey] property. [Key] Count: {KeyProperties.Count}, [ExplicitKey] Count: {ExplicitKeyProperties.Count}");
 
             private static DataException GetNoKeyException(string method) =>
                 new($"{method}<T> only supports an entity with a [Key] or an [ExplicitKey] property");

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -74,7 +74,12 @@ namespace Dapper.Contrib.Extensions
         private static IReadOnlyCollection<PropertyInfo> ExplicitKeyPropertiesCache(Type type) =>
             PropertyInfoCache(type).ExplicitKeyProperties;
 
-        private static IReadOnlyCollection<PropertyInfo> KeyPropertiesCache(Type type) => PropertyInfoCache(type).KeyProperties;
+        private static IEnumerable<PropertyInfo> KeyPropertiesCache(Type type, bool includeId = true)
+        {
+            var properties = PropertyInfoCache(type);
+            return includeId ? properties.KeyPropertiesIncludingId : properties.KeyProperties;
+        }
+
         private static IReadOnlyCollection<PropertyInfo> TypePropertiesCache(Type type) => PropertyInfoCache(type).AllProperties;
 
         private static PropertyInfoWrapper PropertyInfoCache(Type type) =>
@@ -681,6 +686,20 @@ namespace Dapper.Contrib.Extensions
                     InitializeProperties();
 
                     return _keyProperties.AsReadOnly();
+                }
+            }
+
+            public IEnumerable<PropertyInfo> KeyPropertiesIncludingId
+            {
+                get
+                {
+                    InitializeProperties();
+                    if (PropertyNamedId is null)
+                    {
+                        return KeyProperties;
+                    }
+
+                    return KeyProperties.Concat(new[] { PropertyNamedId });
                 }
             }
 

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -74,13 +74,13 @@ namespace Dapper.Contrib.Extensions
         private static IReadOnlyCollection<PropertyInfo> ExplicitKeyPropertiesCache(Type type) =>
             PropertyInfoCache(type).ExplicitKeyProperties;
 
-        private static IEnumerable<PropertyInfo> KeyPropertiesCache(Type type, bool includeId = true)
+        private static IReadOnlyCollection<PropertyInfo> KeyPropertiesCache(Type type, bool includeId = true)
         {
             var properties = PropertyInfoCache(type);
 
             return includeId
                 ? properties.KeyProperties
-                : properties.KeyProperties.Where(p => p != properties.PropertyNamedId);
+                : properties.KeyPropertiesExceptId;
         }
 
         private static IReadOnlyCollection<PropertyInfo> TypePropertiesCache(Type type) => PropertyInfoCache(type).AllProperties;
@@ -693,6 +693,9 @@ namespace Dapper.Contrib.Extensions
                 }
             }
 
+            public IReadOnlyCollection<PropertyInfo> KeyPropertiesExceptId =>
+                KeyProperties.Where(p => p != PropertyNamedId).ToArray();
+
 
             /// <summary>
             ///     Gets the properties that are decorated with [ExplicitKey] attribute
@@ -793,7 +796,7 @@ namespace Dapper.Contrib.Extensions
 
                 exceptionKind = ExceptionKind.None;
 
-                var singleKey = KeyProperties.FirstOrDefault(p => p != idProperty) ??
+                var singleKey = KeyProperties.FirstOrDefault(p => !IsPropertyNamedId(p)) ??
                                 ExplicitKeyProperties.FirstOrDefault() ??
                                 idProperty;
 

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -829,14 +829,9 @@ namespace Dapper.Contrib.Extensions
                 {
                     var propertyKind = GetPropertyKind(propertyInfo);
 
-                    if (propertyKind.HasFlag(PropertyKind.Key | PropertyKind.NamedId))
+                    if (propertyKind.HasFlag(PropertyKind.Key))
                     {
                         keys.Add(propertyInfo);
-
-                        if (propertyNamedId is null && propertyKind.HasFlag(PropertyKind.NamedId))
-                        {
-                            propertyNamedId ??= propertyInfo;
-                        }
                     }
 
                     if (propertyKind.HasFlag(PropertyKind.ExplicitKey))
@@ -847,6 +842,16 @@ namespace Dapper.Contrib.Extensions
                     if (propertyKind.HasFlag(PropertyKind.Computed))
                     {
                         computedProperties.Add(propertyInfo);
+                    }
+
+                    if (propertyKind.HasFlag(PropertyKind.NamedId))
+                    {
+                        propertyNamedId ??= propertyInfo;
+
+                        if (!propertyKind.HasFlag(PropertyKind.ExplicitKey) && !propertyKind.HasFlag(PropertyKind.Key))
+                        {
+                            keys.Add(propertyInfo);
+                        }
                     }
                 }
             }

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -1,14 +1,14 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Reflection;
-using System.Reflection.Emit;
 using System.Text;
+using System.Collections.Concurrent;
+using System.Reflection.Emit;
 using System.Threading;
+
 using Dapper;
-using PropertyAttributes = System.Reflection.PropertyAttributes;
 
 namespace Dapper.Contrib.Extensions
 {


### PR DESCRIPTION
I've moved this PR to a draft until I have the chance to investigate the test failures. In hindsight, it might be worth just changing GetSingleKey<T>() in a minimal way.

Behavior changes:

- In `GetSingleKey<T>()`, only return the property named 'Id' as a fallback if there is no `Key` or `ExplicitKey` property. (fixes https://github.com/DapperLib/Dapper.Contrib/issues/140)
  Note: The new behavior allows manually specifying a key (or explicit key) that is different from the 'Id' property. Any usage that would previously have succeeded (not thrown an exception) should be unaffected.

Refactors/implementation details:

- Introduce `PropertyInfoWrapper` to hold all the relevant information about a type's properties. This object is only mutated within a thread-safe `Lazy<T>`, so we shouldn't have any issues even if multiple threads grab the same instance from a ConcurrentDictionary.

- Move logic about selecting a key into the `PropertyInfoWrapper` and cache the result of `GetSingleKey<T>()`.

- Add `PropertyNamedId` to distinguish properties named 'Id' from properties explicitly annotated with a `KeyAttribute`.

- Add an optional parameter to `KeyPropertiesCache` to specify whether you want to include the `Id` property or not, so that the existing code didn't need to be modified as much.