### PR TITLE
Add all writeable properties to TypeProperties cache

### DIFF
--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -127,7 +127,8 @@ namespace Dapper.Contrib.Extensions
                 return pis.ToList();
             }
 
-            var properties = type.GetProperties().Where(IsWriteable).ToArray();
+            var properties = type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(IsWriteable).ToArray();
             TypeProperties[type.TypeHandle] = properties;
             return properties.ToList();
         }

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -170,10 +170,10 @@ namespace Dapper.Contrib.Extensions
         }
 
         /// <summary>
-        /// Returns a single entity by a single id from table "Ts".
+        /// Returns a single entity by a single id from table "Ts". 
         /// Id must be marked with [Key] attribute.
         /// Entities created from interfaces are tracked/intercepted for changes and used by the Update() extension
-        /// for optimal performance.
+        /// for optimal performance. 
         /// </summary>
         /// <typeparam name="T">Interface or type to create and populate</typeparam>
         /// <param name="connection">Open SqlConnection</param>
@@ -301,7 +301,7 @@ namespace Dapper.Contrib.Extensions
             }
             else
             {
-                //NOTE: This as dynamic trick falls back to handle both our own Table-attribute as well as the one in EntityFramework
+                //NOTE: This as dynamic trick falls back to handle both our own Table-attribute as well as the one in EntityFramework 
                 var tableAttrName =
                     type.GetCustomAttribute<TableAttribute>(false)?.Name
                     ?? (type.GetCustomAttributes(false).FirstOrDefault(attr => attr.GetType().Name == "TableAttribute") as dynamic)?.Name;
@@ -658,7 +658,7 @@ namespace Dapper.Contrib.Extensions
 
             private static void CreateProperty<T>(TypeBuilder typeBuilder, string propertyName, Type propType, MethodInfo setIsDirtyMethod, bool isIdentity)
             {
-                //Define the field and the property
+                //Define the field and the property 
                 var field = typeBuilder.DefineField("_" + propertyName, propType, FieldAttributes.Private);
                 var property = typeBuilder.DefineProperty(propertyName,
                                                System.Reflection.PropertyAttributes.None,


### PR DESCRIPTION
This catches any writeable property, including internal properties that were previously ignored. 

This caught me out because my I created my table models as internal models (which I think is the default now if you're working in VS 2022?) to prevent dependant projects from trying to use them, and only after debugging Dapper.Contrib locally did I realise that only the public properties were being mapped to column names.

For reference here's the error message I was seeing when calling InsertAsync on my internal model:
![image](https://github.com/DapperLib/Dapper.Contrib/assets/127202207/f58c080f-fa5f-4c9c-9636-1769c85befe5)

And the SQL it generated to cause this was: 
`INSERT INTO dbo.my_table () values (); SELECT SCOPE_IDENTITY() id`
