### PR TITLE
Add missing schema name and remove deprecated packages 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ charset = utf-8-bom
 
 # Xml project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
-indent_size = 2
+indent_size = 4
 
 # Xml config files
 [*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
@@ -46,6 +46,20 @@ dotnet_style_collection_initializer = true:suggestion
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+end_of_line = crlf
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
 
 # CSharp code style settings:
 [*.cs]
@@ -78,3 +92,71 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
+csharp_indent_labels = one_less_than_current
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true:silent
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_space_around_binary_operators = before_and_after
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+[*.{cs,vb}]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,7 @@ charset = utf-8-bom
 
 # Xml project files
 [*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
-indent_size = 4
+indent_size = 2
 
 # Xml config files
 [*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
@@ -46,20 +46,6 @@ dotnet_style_collection_initializer = true:suggestion
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_operator_placement_when_wrapping = beginning_of_line
-tab_width = 4
-end_of_line = crlf
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_auto_properties = true:silent
-dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_style_prefer_conditional_expression_over_return = true:silent
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_compound_assignment = true:suggestion
-dotnet_style_prefer_simplified_interpolation = true:suggestion
-dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
-dotnet_style_namespace_match_folder = true:suggestion
 
 # CSharp code style settings:
 [*.cs]
@@ -92,71 +78,3 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
-csharp_indent_labels = one_less_than_current
-csharp_using_directive_placement = outside_namespace:silent
-csharp_prefer_simple_using_statement = true:suggestion
-csharp_prefer_braces = true:silent
-csharp_style_namespace_declarations = block_scoped:silent
-csharp_style_prefer_method_group_conversion = true:silent
-csharp_style_prefer_top_level_statements = true:silent
-csharp_style_prefer_primary_constructors = true:suggestion
-csharp_style_expression_bodied_lambdas = true:silent
-csharp_style_expression_bodied_local_functions = false:silent
-csharp_style_prefer_null_check_over_type_check = true:suggestion
-csharp_prefer_simple_default_expression = true:suggestion
-csharp_style_prefer_local_over_anonymous_function = true:suggestion
-csharp_style_prefer_index_operator = true:suggestion
-csharp_style_prefer_range_operator = true:suggestion
-csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
-csharp_style_prefer_tuple_swap = true:suggestion
-csharp_style_prefer_utf8_string_literals = true:suggestion
-csharp_style_deconstructed_variable_declaration = true:suggestion
-csharp_space_around_binary_operators = before_and_after
-csharp_style_unused_value_assignment_preference = discard_variable:suggestion
-[*.{cs,vb}]
-#### Naming styles ####
-
-# Naming rules
-
-dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
-dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
-dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
-
-dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.types_should_be_pascal_case.symbols = types
-dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
-
-dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
-dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
-
-# Symbol specifications
-
-dotnet_naming_symbols.interface.applicable_kinds = interface
-dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
-
-dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
-dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers = 
-
-dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
-dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers = 
-
-# Naming styles
-
-dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix = 
-dotnet_naming_style.begins_with_i.word_separator = 
-dotnet_naming_style.begins_with_i.capitalization = pascal_case
-
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
-
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
-dotnet_naming_style.pascal_case.capitalization = pascal_case

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,6 @@ jobs:
         MySqlConnectionString: Server=localhost;Port=${{ job.services.mysql.ports[3306] }};Uid=root;Pwd=root;Database=test;Allow User Variables=true
         OLEDBConnectionString: Provider=SQLOLEDB;Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
         PostgesConnectionString: Server=localhost;Port=${{ job.services.postgres.ports[5432] }};Database=test;User Id=postgres;Password=postgres;
-        SqlServerConnectionString: Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
+        SqlServerConnectionString: Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;TrustServerCertificate=True;
     - name: .NET Lib Pack
       run: dotnet pack Build.csproj --no-build -c Release /p:PackageOutputPath=%CD%\.nupkgs /p:CI=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       run: dotnet test tests/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj -c Release --logger GitHubActions /p:CI=true
       env:
         MySqlConnectionString: Server=localhost;Port=${{ job.services.mysql.ports[3306] }};Uid=root;Pwd=root;Database=test;Allow User Variables=true
-        OLEDBConnectionString: Provider=SQLOLEDB;Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;
+        OLEDBConnectionString: Provider=SQLOLEDB;Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;TrustServerCertificate=True;
         PostgesConnectionString: Server=localhost;Port=${{ job.services.postgres.ports[5432] }};Database=test;User Id=postgres;Password=postgres;
         SqlServerConnectionString: Server=tcp:localhost,${{ job.services.sqlserver.ports[1433] }};Database=tempdb;User Id=sa;Password=Password.;TrustServerCertificate=True;
     - name: .NET Lib Pack

--- a/Dapper.sln
+++ b/Dapper.sln
@@ -16,7 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		version.json = version.json
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Contrib", "Dapper.Contrib\Dapper.Contrib.csproj", "{4E409F8F-CFBB-4332-8B0A-FD5A283051FD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Contrib", "src\Dapper.Contrib\Dapper.Contrib.csproj", "{4E409F8F-CFBB-4332-8B0A-FD5A283051FD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.Tests.Contrib", "tests\Dapper.Tests.Contrib\Dapper.Tests.Contrib.csproj", "{DAB3C5B7-BCD1-4A5F-BB6B-50D2BB63DB4A}"
 EndProject

--- a/Dapper.sln
+++ b/Dapper.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28917.182
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35312.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A34907DF-958A-4E4C-8491-84CF303FD13E}"
 	ProjectSection(SolutionItems) = preProject
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		docs\index.md = docs\index.md
 		License.txt = License.txt
+		.github\workflows\main.yml = .github\workflows\main.yml
 		nuget.config = nuget.config
 		Readme.md = Readme.md
 		version.json = version.json

--- a/Readme.md
+++ b/Readme.md
@@ -136,7 +136,7 @@ Dapper.Contrib makes use of some optional attributes:
 * `[Table("Tablename", Schema = "SchemaName")]` - use another table name instead of the (by default pluralized) name of the class, Schema can be optionally passed as well.
 
     ```csharp
-    [Table ("emps",Schema = "emp")]
+    [Table ("emps", Schema = "emp")]
     public class Employee
     {
         public int Id { get; set; }

--- a/Readme.md
+++ b/Readme.md
@@ -133,10 +133,10 @@ Special Attributes
 ----------
 Dapper.Contrib makes use of some optional attributes:
 
-* `[Table("Tablename")]` - use another table name instead of the (by default pluralized) name of the class
+* `[Table("Tablename", Schema = "SchemaName")]` - use another table name instead of the (by default pluralized) name of the class, Schema can be optionally passed as well.
 
     ```csharp
-    [Table ("emps")]
+    [Table ("emps",Schema = "emp")]
     public class Employee
     {
         public int Id { get; set; }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,8 +27,7 @@ environment:
   PostgesConnectionString: Server=localhost;Port=5432;User Id=postgres;Password=Password12!;Database=test
   SqlServerConnectionString: Server=(local)\SQL2019;Database=tempdb;User ID=sa;Password=Password12!
 
-services:
-  - mysql
+services:  
   - postgresql13
 
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
   POSTGRES_ENV_POSTGRES_PASSWORD: Password12!
   POSTGRES_ENV_POSTGRES_DB: test
   # MySQL
-  MYSQL_PATH: C:\Program Files\MySQL\MySQL Server 8
+  MYSQL_PATH: C:\Program Files\MySQL\MySQL Server 8.0
   MYSQL_PWD: Password12!
   MYSQL_ENV_MYSQL_USER: root
   MYSQL_ENV_MYSQL_PASSWORD: Password12!

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 skip_branch_with_pr: true
 skip_tags: true
@@ -9,7 +9,7 @@ skip_commits:
 environment:
   Appveyor: true
   # Postgres
-  POSTGRES_PATH: C:\Program Files\PostgreSQL\9.6
+  POSTGRES_PATH: C:\Program Files\PostgreSQL\13
   PGUSER: postgres
   PGPASSWORD: Password12!
   POSTGRES_ENV_POSTGRES_USER: postgres
@@ -29,7 +29,7 @@ environment:
 
 services:
   - mysql
-  - postgresql
+  - postgresql13
 
 init:
   - git config --global core.autocrlf input

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,9 +32,11 @@ services:
   - postgresql13
 
 init:
+  - ps: Start-Service MySQL80
   - git config --global core.autocrlf input
   - SET PATH=%POSTGRES_PATH%\bin;%MYSQL_PATH%\bin;%PATH%
   - net start MSSQL$SQL2019
+  
 
 nuget:
   disable_publish_on_pr: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ environment:
   MySqlConnectionString: Server=localhost;Database=test;Uid=root;Pwd=Password12!
   OLEDBConnectionString: Provider=SQLOLEDB;Data Source=(local)\SQL2019;Initial Catalog=tempdb;User Id=sa;Password=Password12!
   PostgesConnectionString: Server=localhost;Port=5432;User Id=postgres;Password=Password12!;Database=test
-  SqlServerConnectionString: Server=(local)\SQL2019;Database=tempdb;User ID=sa;Password=Password12!
+  SqlServerConnectionString: Server=(local)\SQL2019;Database=tempdb;User ID=sa;Password=Password12!;TrustServerCertificate=True
 
 services:  
   - postgresql13

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
   POSTGRES_ENV_POSTGRES_PASSWORD: Password12!
   POSTGRES_ENV_POSTGRES_DB: test
   # MySQL
-  MYSQL_PATH: C:\Program Files\MySQL\MySQL Server 8.0
+  MYSQL_PATH: C:\Program Files\MySQL\MySQL Server 8
   MYSQL_PWD: Password12!
   MYSQL_ENV_MYSQL_USER: root
   MYSQL_ENV_MYSQL_PASSWORD: Password12!

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
   POSTGRES_ENV_POSTGRES_PASSWORD: Password12!
   POSTGRES_ENV_POSTGRES_DB: test
   # MySQL
-  MYSQL_PATH: C:\Program Files\MySql\MySQL Server 5.7
+  MYSQL_PATH: C:\Program Files\MySQL\MySQL Server 8.0
   MYSQL_PWD: Password12!
   MYSQL_ENV_MYSQL_USER: root
   MYSQL_ENV_MYSQL_PASSWORD: Password12!

--- a/src/Dapper.Contrib/Dapper.Contrib.csproj
+++ b/src/Dapper.Contrib/Dapper.Contrib.csproj
@@ -5,12 +5,12 @@
     <PackageTags>orm;sql;micro-orm;dapper</PackageTags>
     <Description>The official collection of get, insert, update and delete helpers for Dapper.net. Also handles lists of entities and optional "dirty" tracking of interface-based entities.</Description>
     <Authors>Sam Saffron;Johan Danforth</Authors>
-    <TargetFrameworks>net461;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CA1050</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.78" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />

--- a/src/Dapper.Contrib/Dapper.Contrib.csproj
+++ b/src/Dapper.Contrib/Dapper.Contrib.csproj
@@ -19,4 +19,12 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.143" />
+  </ItemGroup>
 </Project>

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -728,6 +728,10 @@ namespace Dapper.Contrib.Extensions
         /// The name of the table in the database
         /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// The schema of the table in the database
+        /// </summary>
         public string Schema { get; set; }
     }
 

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -186,7 +186,7 @@ namespace Dapper.Contrib.Extensions
 
             if (type.IsInterface)
             {
-                if (!(connection.Query(sql, dynParams).FirstOrDefault() is IDictionary<string, object> res))
+                if (connection.Query(sql, dynParams).FirstOrDefault() is not IDictionary<string, object> res)
                 {
                     return null;
                 }
@@ -305,7 +305,7 @@ namespace Dapper.Contrib.Extensions
                 else
                 {
                     name = type.Name + "s";
-                    if (type.IsInterface && name.StartsWith("I"))
+                    if (type.IsInterface && name.StartsWith('I'))
                         name = name.Substring(1);
                 }
             }
@@ -607,7 +607,7 @@ namespace Dapper.Contrib.Extensions
                 return (T)Activator.CreateInstance(generatedType);
             }
 
-            private static MethodInfo CreateIsDirtyProperty(TypeBuilder typeBuilder)
+            private static MethodBuilder CreateIsDirtyProperty(TypeBuilder typeBuilder)
             {
                 var propType = typeof(bool);
                 var field = typeBuilder.DefineField("_" + nameof(IProxy.IsDirty), propType, FieldAttributes.Private);
@@ -648,7 +648,7 @@ namespace Dapper.Contrib.Extensions
                 return currSetPropMthdBldr;
             }
 
-            private static void CreateProperty<T>(TypeBuilder typeBuilder, string propertyName, Type propType, MethodInfo setIsDirtyMethod, bool isIdentity)
+            private static void CreateProperty<T>(TypeBuilder typeBuilder, string propertyName, Type propType, MethodBuilder setIsDirtyMethod, bool isIdentity)
             {
                 //Define the field and the property 
                 var field = typeBuilder.DefineField("_" + propertyName, propType, FieldAttributes.Private);

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 using System.Text;
 using System.Collections.Concurrent;
 using System.Reflection.Emit;
-using System.Threading;
 
 using Dapper;
 

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -291,11 +291,11 @@ namespace Dapper.Contrib.Extensions
                     type.GetCustomAttribute<TableAttribute>(false)?.Name
                     ?? (type.GetCustomAttributes(false).FirstOrDefault(attr => attr.GetType().Name == "TableAttribute") as dynamic)?.Name;
                 
-                var schemaAttrr = type.GetCustomAttribute<TableAttribute>(false)?.Schema;
+                var tableAttrSchema = type.GetCustomAttribute<TableAttribute>(false)?.Schema;
                 
-                if (!string.IsNullOrEmpty(schemaAttrr))
+                if (!string.IsNullOrEmpty(tableAttrSchema))
                 {
-                    tableAttrName = $"{schemaAttrr}.{tableAttrName}";
+                    tableAttrName = $"{tableAttrSchema}.{tableAttrName}";
                 }
 
                 if (tableAttrName != null)

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -1,16 +1,16 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Collections.Concurrent;
 using System.Reflection.Emit;
-
+using System.Text;
 using Dapper;
 
 namespace Dapper.Contrib.Extensions
 {
+
     /// <summary>
     /// The Dapper.Contrib extensions for Dapper
     /// </summary>
@@ -290,9 +290,9 @@ namespace Dapper.Contrib.Extensions
                 var tableAttrName =
                     type.GetCustomAttribute<TableAttribute>(false)?.Name
                     ?? (type.GetCustomAttributes(false).FirstOrDefault(attr => attr.GetType().Name == "TableAttribute") as dynamic)?.Name;
-                
+
                 var tableAttrSchema = type.GetCustomAttribute<TableAttribute>(false)?.Schema;
-                
+
                 if (!string.IsNullOrEmpty(tableAttrSchema))
                 {
                     tableAttrName = $"{tableAttrSchema}.{tableAttrName}";

--- a/src/Dapper.Contrib/SqlMapperExtensions.cs
+++ b/src/Dapper.Contrib/SqlMapperExtensions.cs
@@ -291,6 +291,13 @@ namespace Dapper.Contrib.Extensions
                 var tableAttrName =
                     type.GetCustomAttribute<TableAttribute>(false)?.Name
                     ?? (type.GetCustomAttributes(false).FirstOrDefault(attr => attr.GetType().Name == "TableAttribute") as dynamic)?.Name;
+                
+                var schemaAttrr = type.GetCustomAttribute<TableAttribute>(false)?.Schema;
+                
+                if (!string.IsNullOrEmpty(schemaAttrr))
+                {
+                    tableAttrName = $"{schemaAttrr}.{tableAttrName}";
+                }
 
                 if (tableAttrName != null)
                 {
@@ -710,15 +717,18 @@ namespace Dapper.Contrib.Extensions
         /// Creates a table mapping to a specific name for Dapper.Contrib commands
         /// </summary>
         /// <param name="tableName">The name of this table in the database.</param>
-        public TableAttribute(string tableName)
+        /// <param name="schema">The schema name of this table in the database</param>
+        public TableAttribute(string tableName, string schema = "")
         {
             Name = tableName;
+            Schema = schema;
         }
 
         /// <summary>
         /// The name of the table in the database
         /// </summary>
         public string Name { get; set; }
+        public string Schema { get; set; }
     }
 
     /// <summary>

--- a/tests/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
+++ b/tests/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>Dapper.Tests.Contrib</AssemblyName>
     <Description>Dapper Contrib Test Suite</Description>
-    <TargetFrameworks>netcoreapp3.1;net462;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1816;IDE0063;xUnit1004</NoWarn>
   </PropertyGroup>
   <ItemGroup>
@@ -13,9 +13,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dapper.SqlBuilder" Version="2.0.78" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.0" />
-    <PackageReference Include="MySqlConnector" Version="1.1.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.33" />
+    <PackageReference Include="MySqlConnector" Version="1.1.0" />   
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="Microsoft.CSharp" />

--- a/tests/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
+++ b/tests/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
@@ -14,10 +14,28 @@
   <ItemGroup>
     <PackageReference Include="Dapper.SqlBuilder" Version="2.0.78" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.33" />
-    <PackageReference Include="MySqlConnector" Version="1.1.0" />   
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.8" />
+    <PackageReference Include="MySqlConnector" Version="2.3.7" />   
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="GitHubActionsTestLogger" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.143" />
+    <PackageReference Update="xunit" Version="2.9.0" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/tests/Dapper.Tests.Contrib/TestSuite.Async.cs
+++ b/tests/Dapper.Tests.Contrib/TestSuite.Async.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Dapper.Contrib.Extensions;
-using FactAttribute = Dapper.Tests.Contrib.SkippableFactAttribute;
 using Xunit;
 
 namespace Dapper.Tests.Contrib
@@ -305,9 +304,9 @@ namespace Dapper.Tests.Contrib
                 await connection.DeleteAllAsync<User>().ConfigureAwait(false);
 
                 var total = await connection.InsertAsync(helper(users)).ConfigureAwait(false);
-                Assert.Equal(total, numberOfEntities);
+                Assert.Equal(numberOfEntities, total);
                 users = connection.Query<User>("select * from Users").ToList();
-                Assert.Equal(users.Count, numberOfEntities);
+                Assert.Equal(numberOfEntities, users.Count);
             }
         }
 
@@ -343,7 +342,7 @@ namespace Dapper.Tests.Contrib
                 await connection.DeleteAllAsync<User>().ConfigureAwait(false);
 
                 var total = await connection.InsertAsync(helper(users)).ConfigureAwait(false);
-                Assert.Equal(total, numberOfEntities);
+                Assert.Equal(numberOfEntities, total);
                 users = connection.Query<User>("select * from Users").ToList();
                 Assert.Equal(users.Count, numberOfEntities);
                 foreach (var user in users)
@@ -377,7 +376,7 @@ namespace Dapper.Tests.Contrib
         private async Task DeleteHelperAsync<T>(Func<IEnumerable<User>, T> helper)
             where T : class
         {
-            const int numberOfEntities = 10;
+            int numberOfEntities = 10;
 
             var users = new List<User>(numberOfEntities);
             for (var i = 0; i < numberOfEntities; i++)
@@ -388,14 +387,14 @@ namespace Dapper.Tests.Contrib
                 await connection.DeleteAllAsync<User>().ConfigureAwait(false);
 
                 var total = await connection.InsertAsync(helper(users)).ConfigureAwait(false);
-                Assert.Equal(total, numberOfEntities);
+                Assert.Equal(numberOfEntities, total);
                 users = connection.Query<User>("select * from Users").ToList();
-                Assert.Equal(users.Count, numberOfEntities);
+                Assert.Equal(numberOfEntities, users.Count);
 
                 var usersToDelete = users.Take(10).ToList();
                 await connection.DeleteAsync(helper(usersToDelete)).ConfigureAwait(false);
                 users = connection.Query<User>("select * from Users").ToList();
-                Assert.Equal(users.Count, numberOfEntities - 10);
+                Assert.Equal(numberOfEntities - 10, users.Count);
             }
         }
 
@@ -413,11 +412,11 @@ namespace Dapper.Tests.Contrib
                 await connection.DeleteAllAsync<User>().ConfigureAwait(false);
 
                 var total = await connection.InsertAsync(users).ConfigureAwait(false);
-                Assert.Equal(total, numberOfEntities);
+                Assert.Equal(numberOfEntities, total);
                 users = (List<User>)await connection.GetAllAsync<User>().ConfigureAwait(false);
-                Assert.Equal(users.Count, numberOfEntities);
+                Assert.Equal(numberOfEntities, users.Count);
                 var iusers = await connection.GetAllAsync<IUser>().ConfigureAwait(false);
-                Assert.Equal(iusers.ToList().Count, numberOfEntities);
+                Assert.Equal(numberOfEntities, iusers.ToList().Count);
             }
         }
 

--- a/tests/Dapper.Tests.Contrib/TestSuite.Async.cs
+++ b/tests/Dapper.Tests.Contrib/TestSuite.Async.cs
@@ -124,7 +124,7 @@ namespace Dapper.Tests.Contrib
                 var list2 = (await connection.QueryAsync<ObjectY>("select * from ObjectY").ConfigureAwait(false)).ToList();
                 Assert.Equal(list2.Count, originalyCount + 1);
                 o2 = await connection.GetAsync<ObjectY>(id).ConfigureAwait(false);
-                Assert.Equal(o2.ObjectYId, id);
+                Assert.Equal(id, o2.ObjectYId);
                 o2.Name = "Bar";
                 await connection.UpdateAsync(o2).ConfigureAwait(false);
                 o2 = await connection.GetAsync<ObjectY>(id).ConfigureAwait(false);
@@ -344,7 +344,7 @@ namespace Dapper.Tests.Contrib
                 var total = await connection.InsertAsync(helper(users)).ConfigureAwait(false);
                 Assert.Equal(numberOfEntities, total);
                 users = connection.Query<User>("select * from Users").ToList();
-                Assert.Equal(users.Count, numberOfEntities);
+                Assert.Equal(numberOfEntities, users.Count);
                 foreach (var user in users)
                 {
                     user.Name += " updated";
@@ -435,12 +435,12 @@ namespace Dapper.Tests.Contrib
                 Assert.Equal(new DateTime(2011, 07, 14), value1.DateValue.Value);
 
                 var value2 = await connection.GetAsync<INullableDate>(id2).ConfigureAwait(false);
-                Assert.True(value2.DateValue == null);
+                Assert.Null(value2.DateValue);
 
                 var value3 = await connection.GetAllAsync<INullableDate>().ConfigureAwait(false);
                 var valuesList = value3.ToList();
                 Assert.Equal(new DateTime(2011, 07, 14), valuesList[0].DateValue.Value);
-                Assert.True(valuesList[1].DateValue == null);
+                Assert.Null(valuesList[1].DateValue);
             }
         }
 

--- a/tests/Dapper.Tests.Contrib/TestSuite.cs
+++ b/tests/Dapper.Tests.Contrib/TestSuite.cs
@@ -5,8 +5,6 @@ using System.Linq;
 using Dapper.Contrib.Extensions;
 using Xunit;
 
-using FactAttribute = Dapper.Tests.Contrib.SkippableFactAttribute;
-
 namespace Dapper.Tests.Contrib
 {
     [Table("ObjectX")]
@@ -389,9 +387,9 @@ namespace Dapper.Tests.Contrib
                 connection.DeleteAll<User>();
 
                 var total = connection.Insert(helper(users));
-                Assert.Equal(total, numberOfEntities);
+                Assert.Equal(numberOfEntities, total);
                 users = connection.Query<User>("select * from Users").ToList();
-                Assert.Equal(users.Count, numberOfEntities);
+                Assert.Equal(numberOfEntities, users.Count);
             }
         }
 
@@ -427,9 +425,9 @@ namespace Dapper.Tests.Contrib
                 connection.DeleteAll<User>();
 
                 var total = connection.Insert(helper(users));
-                Assert.Equal(total, numberOfEntities);
+                Assert.Equal(numberOfEntities, total);
                 users = connection.Query<User>("select * from Users").ToList();
-                Assert.Equal(users.Count, numberOfEntities);
+                Assert.Equal(numberOfEntities, users.Count);
                 foreach (var user in users)
                 {
                     user.Name += " updated";
@@ -461,7 +459,7 @@ namespace Dapper.Tests.Contrib
         private void DeleteHelper<T>(Func<IEnumerable<User>, T> helper)
             where T : class
         {
-            const int numberOfEntities = 10;
+            int numberOfEntities = 10;
 
             var users = new List<User>(numberOfEntities);
             for (var i = 0; i < numberOfEntities; i++)
@@ -472,14 +470,14 @@ namespace Dapper.Tests.Contrib
                 connection.DeleteAll<User>();
 
                 var total = connection.Insert(helper(users));
-                Assert.Equal(total, numberOfEntities);
+                Assert.Equal(numberOfEntities, total);
                 users = connection.Query<User>("select * from Users").ToList();
-                Assert.Equal(users.Count, numberOfEntities);
+                Assert.Equal(numberOfEntities, users.Count);
 
                 var usersToDelete = users.Take(10).ToList();
                 connection.Delete(helper(usersToDelete));
                 users = connection.Query<User>("select * from Users").ToList();
-                Assert.Equal(users.Count, numberOfEntities - 10);
+                Assert.Equal(numberOfEntities - 10, users.Count);
             }
         }
 
@@ -597,13 +595,13 @@ namespace Dapper.Tests.Contrib
                 connection.DeleteAll<User>();
 
                 var total = connection.Insert(users);
-                Assert.Equal(total, numberOfEntities);
+                Assert.Equal(numberOfEntities, total);
                 users = connection.GetAll<User>().ToList();
-                Assert.Equal(users.Count, numberOfEntities);
+                Assert.Equal(numberOfEntities, users.Count);
                 var iusers = connection.GetAll<IUser>().ToList();
-                Assert.Equal(iusers.Count, numberOfEntities);
+                Assert.Equal(numberOfEntities, iusers.Count);
                 for (var i = 0; i < numberOfEntities; i++)
-                    Assert.Equal(iusers[i].Age, i);
+                    Assert.Equal(i, iusers[i].Age);
             }
         }
 

--- a/tests/Dapper.Tests.Contrib/TestSuite.cs
+++ b/tests/Dapper.Tests.Contrib/TestSuite.cs
@@ -245,7 +245,7 @@ namespace Dapper.Tests.Contrib
                 var list2 = connection.Query<ObjectY>("select * from ObjectY").ToList();
                 Assert.Equal(list2.Count, originalyCount + 1);
                 o2 = connection.Get<ObjectY>(id);
-                Assert.Equal(o2.ObjectYId, id);
+                Assert.Equal(id, o2.ObjectYId);
                 o2.Name = "Bar";
                 connection.Update(o2);
                 o2 = connection.Get<ObjectY>(id);
@@ -282,7 +282,7 @@ namespace Dapper.Tests.Contrib
                 var list2 = connection.Query<ObjectZ>("select * from ObjectZ").ToList();
                 Assert.Single(list2);
                 o2 = connection.Get<ObjectZ>(id);
-                Assert.Equal(o2.Id, id);
+                Assert.Equal(id, o2.Id);
             }
         }
 
@@ -296,7 +296,7 @@ namespace Dapper.Tests.Contrib
                 Assert.True(id > 0); // 1-n are valid here, due to parallel tests
                 var item = connection.Get<Stuff>(id);
                 Assert.Equal(item.TheId, (short)id);
-                Assert.Equal(item.Name, name);
+                Assert.Equal(name, item.Name);
             }
         }
 
@@ -567,7 +567,7 @@ namespace Dapper.Tests.Contrib
                             return tableattr.Name;
 
                         var name = type.Name + "s";
-                        if (type.IsInterface && name.StartsWith("I"))
+                        if (type.IsInterface && name.StartsWith('I'))
                             return name.Substring(1);
                         return name;
                 }
@@ -620,11 +620,11 @@ namespace Dapper.Tests.Contrib
                 Assert.Equal(new DateTime(2011, 07, 14), value1.DateValue.Value);
 
                 var value2 = connection.Get<INullableDate>(id2);
-                Assert.True(value2.DateValue == null);
+                Assert.Null(value2.DateValue);
 
                 var value3 = connection.GetAll<INullableDate>().ToList();
                 Assert.Equal(new DateTime(2011, 07, 14), value3[0].DateValue.Value);
-                Assert.True(value3[1].DateValue == null);
+                Assert.Null(value3[1].DateValue);
             }
         }
 

--- a/tests/Dapper.Tests.Contrib/TestSuites.cs
+++ b/tests/Dapper.Tests.Contrib/TestSuites.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.Data.Sqlite;
+﻿using Microsoft.Data.SqlClient;
+using Microsoft.Data.Sqlite;
 using MySqlConnector;
 using System;
 using System.Data;
-using System.Data.SqlClient;
 using System.IO;
 using Xunit;
 using Xunit.Sdk;


### PR DESCRIPTION
- fixes the error where the Schema name is necessary for the tables removing potential dependency on the System.ComponentModel.DataAnnotations.Schema in Dapper.Bulk, allowing to use compatible format eg.
`[Table("routes", Schema = "gtfs")]`

- adds Microsoft.Data.SqlClient instead of System.Data.SqlClient. 
- removes vulnerable and deprecated packages 
- updates the appveor to use MySQL 8 
